### PR TITLE
Add 16550A UART console support

### DIFF
--- a/src/machine.h
+++ b/src/machine.h
@@ -161,3 +161,8 @@ BlockDevice *block_device_init_http(const char *url,
                                     int max_cache_size_kb,
                                     void (*start_cb)(void *opaque),
                                     void *start_opaque);
+
+/* riscv_machine.c */
+void uart_rx_data(VirtMachine *v, uint8_t *buf, int size);
+int  uart_can_rx(VirtMachine *v);
+

--- a/src/riscvemu.c
+++ b/src/riscvemu.c
@@ -553,13 +553,13 @@ void virt_machine_run(VirtMachine *m)
     FD_ZERO(&efds);
     fd_max = -1;
 #ifndef _WIN32
-    if (m->console_dev && virtio_console_can_write_data(m->console_dev)) {
+    if (m->console_dev && (uart_can_rx(m) || virtio_console_can_write_data(m->console_dev))) {
         STDIODevice *s = (STDIODevice *)m->console->opaque;
         stdin_fd = s->stdin_fd;
         FD_SET(stdin_fd, &rfds);
         fd_max = stdin_fd;
 
-        if (s->resize_pending) {
+        if (s->resize_pending && virtio_console_can_write_data(m->console_dev)) {
             int width, height;
             console_get_size(s, &width, &height);
             virtio_console_resize_event(m->console_dev, width, height);
@@ -583,12 +583,16 @@ void virt_machine_run(VirtMachine *m)
 #ifndef _WIN32
         if (m->console_dev && FD_ISSET(stdin_fd, &rfds)) {
             uint8_t buf[128];
-            int ret, len;
-            len = virtio_console_get_write_len(m->console_dev);
-            len = min_int(len, sizeof(buf));
+            int ret, len = sizeof(buf), ulen = uart_can_rx(m);
+	    if (virtio_console_can_write_data(m->console_dev))
+		len = min_int(len, virtio_console_get_write_len(m->console_dev));
+	    if (ulen)
+		len = min_int(len, ulen);
             ret = m->console->read_data(m->console->opaque, buf, len);
             if (ret > 0) {
-                virtio_console_write_data(m->console_dev, buf, ret);
+		uart_rx_data(m, buf, ret);
+		if (virtio_console_can_write_data(m->console_dev))
+		    virtio_console_write_data(m->console_dev, buf, ret);
             }
         }
 #endif


### PR DESCRIPTION
HTIF is deprecated, and tohost/fromhost locations are no longer fixed.
UART is standard and more easily supported with recent bootloaders.
(Linux can use either virtio or this UART.)