### PR TITLE
Disassembly fixes and prettier formatting.

### DIFF
--- a/src/riscvemu_template.h
+++ b/src/riscvemu_template.h
@@ -305,7 +305,7 @@ static void no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s,
             /* Includes MMU exception, illegal opcode etc. */
 #if defined(CONFIG_SIM_TRACE)
             print_ins_trace(s, s->simcpu->clock, s->sim_epc,
-                            s->sim_exception_ins, s->sim_epc_str, s->priv,
+                            s->sim_exception_ins, s->sim_epc_str, 0, 0, 0, s->priv,
                             "exception");
 #endif
             break;
@@ -324,8 +324,8 @@ static void no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s,
             // sleep(1);
 #if defined(CONFIG_SIM_TRACE)
             print_ins_trace(s, s->simcpu->clock, s->sim_epc,
-                            s->sim_exception_ins, s->sim_epc_str, s->priv,
-                            "emulating complex opcode");
+                            s->sim_exception_ins, s->sim_epc_str, 0, 0, 0, s->priv,
+                            "emul");
 #endif
             break;
 
@@ -334,7 +334,7 @@ static void no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s,
                we must exit to virt_machine_run() to receive interrupts */
 #if defined(CONFIG_SIM_TRACE)
             print_ins_trace(s, s->simcpu->clock, s->sim_epc, 0, "",
-                            s->priv, "timeout");
+                            0, 0, 0, s->priv, "timeout");
 #endif
             break;
 

--- a/src/riscvsim/common_core_utils.h
+++ b/src/riscvsim/common_core_utils.h
@@ -105,6 +105,6 @@ int handle_branch_with_bpu(struct RISCVCPUState *s, IMapEntry *e);
 int handle_branch_no_bpu(struct RISCVCPUState *s, IMapEntry *e);
 
 void copy_cache_stats_to_global_stats(struct RISCVCPUState *s);
-void print_ins_trace(struct RISCVCPUState *s, uint64_t cycle, target_ulong pc, uint32_t insn, const char *insn_str, int mode, const char *exception);
+void print_ins_trace(struct RISCVCPUState *s, uint64_t cycle, target_ulong pc, uint32_t insn, const char *insn_str, int rd, uint64_t rdvalue, uint64_t ea, int mode, const char *exception);
 
 #endif

--- a/src/riscvsim/inorder_backend.c
+++ b/src/riscvsim/inorder_backend.c
@@ -499,7 +499,8 @@ in_core_commit(INCore *core)
 
 #if defined(CONFIG_SIM_TRACE)
         print_ins_trace(s, core->simcpu->clock, e->ins.pc, e->ins.binary, e->ins.str,
-                        s->priv, "simulated");
+                        (e->ins.has_dest ? e->ins.rd : 0), e->ins.buffer, e->ins.mem_addr,
+			s->priv, "sim");
 #endif
 
         if (s->sim_params->enable_stats_display)

--- a/src/riscvsim/ooo_backend.c
+++ b/src/riscvsim/ooo_backend.c
@@ -603,8 +603,10 @@ oo_core_rob_commit(OOCore *core)
 
 #if defined(CONFIG_SIM_TRACE)
                     print_ins_trace(s, s->simcpu->clock, e->ins.pc,
-                                    e->ins.binary, e->ins.str, s->priv,
-                                    "simulated");
+                                    e->ins.binary, e->ins.str,
+				    (e->ins.has_dest ? e->ins.rd : 0),
+				    core->prf_int[e->ins.pdest].val,
+				    e->ins.mem_addr, s->priv, "sim-ooo");
 #endif
 
                     if (s->sim_params->enable_stats_display)


### PR DESCRIPTION
Fix errors, use more standard disassembly formats.
Show destination register value and effective address in disassembly.
Align operands column.
Use more compact output for all this to fit reasonably.

Various other errors and omissions remain to be fixed
(fence operands; showing shorter versions of instructions; etc).
This was a minimum set of fixes to help debugging.